### PR TITLE
Support python 3.13

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-          - "3.12"
+          - "3.13"
     name: "make test #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v4

--- a/libs/voyageai/pyproject.toml
+++ b/libs/voyageai/pyproject.toml
@@ -8,7 +8,7 @@ includes = []
 [project]
 authors = []
 license = { text = "MIT" }
-requires-python = "<=3.13,>=3.10"
+requires-python = "<3.14,>=3.10"
 dependencies = [
     "langchain-core>=1.0.0",
     "voyageai<1,>=0.3.7",

--- a/libs/voyageai/uv.lock
+++ b/libs/voyageai/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <=3.13"
+requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -582,7 +582,7 @@ wheels = [
 
 [[package]]
 name = "langchain-voyageai"
-version = "0.3.1"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Current version spec <= 3.13 allows only 3.13.0. I cannot find any incompatibilities with python 3.13, so bumping max version.